### PR TITLE
Use default port 80 for HTTP 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Default Container mDNS hostnames:
 
 Default Ports that are opened:
 
-- NMOS Registry/Controller on port 8010
-- NMOS Virtual Node on port 11000
+- NMOS Registry/Controller on port 80
+- NMOS Virtual Node on port 80
 - AMWA NMOS Testing Tool on port 5000
 - MQTT Broker on port 1883
 
@@ -79,22 +79,22 @@ Assuming your client device is correctly supporting mDNS and is on the same LAN 
 
 Browse to the NMOS Controller
 ```
-http://nmos-registry.local:8010/admin
+http://nmos-registry.local/admin
 ```
 
 Browse to the AMWA NMOS Testing Tool
 ```
-http://nmos-testing.local:5000
+http://nmos-testing.local:5000/
 ```
 
-Browse to the JSON Output of the NMOS Registry
+Browse to the APIs of the NMOS Registry
 ```
-http://nmos-registry.local:8010/x-nmos
+http://nmos-registry.local/x-nmos
 ```
 
-Browse to the JSON Output of the NMOS Node
+Browse to the APIs of the NMOS Node
 ```
-http://nmos-virtnode.local:11000/x-nmos
+http://nmos-virtnode.local/x-nmos
 ```
 
 ### Needs more work to briefly explain what can/can't be done and the use of the "registration.sh" script to disable the nmos-registry so that the testing tool can be used to test the nmos-virtnode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: nmos-registry
     hostname: nmos-registry
     ports:
-    - "8010-8011:8010-8011"
+    - "80-81:80-81"
     - "1883:1883"
     volumes:
     - "./registry.json:/home/registry.json"
@@ -26,7 +26,7 @@ services:
     container_name: nmos-virtnode
     hostname: nmos-virtnode
     ports:
-    - "11000-11001:11000-11001"
+    - "80-81:80-81"
     volumes:
     - "./node.json:/home/node.json"
     environment:

--- a/node.json
+++ b/node.json
@@ -1,7 +1,7 @@
 {
 "logging_level": -20,
-"http_port": 11000,
-"events_ws_port": 11001,
+"http_port": 80,
+"events_ws_port": 81,
 "domain": "local",
 "label": "easy-nmos-node",
 "how_many": 2

--- a/registration.sh
+++ b/registration.sh
@@ -5,7 +5,7 @@ CMD=${1:-enable}
 enable () {
   echo "Attempting to enable registration API on nmos-registry"
 
-  curl http://nmos-registry.local:8010/settings/all -X PATCH -H "Content-Type: application/json" -d "{\"registration_available\":true}"
+  curl http://nmos-registry.local/settings/all -X PATCH -H "Content-Type: application/json" -d "{\"registration_available\":true}"
   if [ $? -eq 0 ]; then
     echo -e "\nOK - Successfully enabled"
   else
@@ -16,7 +16,7 @@ enable () {
 disable () {
   echo "Attempting to disable registration API on nmos-registry"
 
-  curl http://nmos-registry.local:8010/settings/all -X PATCH -H "Content-Type: application/json" -d "{\"registration_available\":false}"
+  curl http://nmos-registry.local/settings/all -X PATCH -H "Content-Type: application/json" -d "{\"registration_available\":false}"
   if [ $? -eq 0 ]; then
     echo -e "\nOK - Successfully disabled"
   else

--- a/registry.json
+++ b/registry.json
@@ -3,7 +3,7 @@
 "logging_level": -20,
 "http_trace": false,
 "label": "easy-nmos-registry",
-"http_port": 8010,
-"query_ws_port": 8011,
+"http_port": 80,
+"query_ws_port": 81,
 "registration_expiry_interval": 12
 }


### PR DESCRIPTION
...on the Registry and Virtual Node containers (and port 81 for WebSocket).

Does it matter that registry.json and node.json configs thus can't be used in a single container?