### PR TITLE
Fix docker-compose upgrade.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,5 +14,4 @@ chmod 755 ./get-docker.sh
 #Install Docker Compose
 curl -L "https://github.com/docker/compose/releases/download/$(get_latest_release)/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod 755 /usr/local/bin/docker-compose
-ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose


### PR DESCRIPTION
Install script fails when an older version was previously installed.